### PR TITLE
Fix for ceres and photutils for Imaging Pipeline

### DIFF
--- a/rules/cfitsio.sh
+++ b/rules/cfitsio.sh
@@ -3,6 +3,8 @@ curl -SL http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3410.tar.gz \
     && tar xzf cfitsio3410.tar.gz \
     && cd cfitsio \
     && CC="@CC@" CFLAGS="@CFLAGS@" ./configure @CROSS@ --prefix=@AUX_PREFIX@ \
-    && make -j 4 && make shared && make install \
+    && make -j 4 && make shared \
+    && make fpack && make funpack \
+    && make install \
     && cd .. \
     && rm -rf cfitsio*

--- a/rules/photutils.sh
+++ b/rules/photutils.sh
@@ -1,0 +1,7 @@
+curl -SL https://pypi.python.org/packages/0d/c4/fca2906c5cf10547743357c813ab051419a9aeb383e14baaf7b7eee3f89a/photutils-0.3.2.tar.gz#md5=7811873224b22c6ff8fef732e1d93daa \
+    -o photutils-0.3.2.tar.gz \
+    && tar xzf photutils-0.3.2.tar.gz \
+    && cd photutils-0.3.2 \
+    && python setup.py install --prefix=@AUX_PREFIX@ \
+    && cd .. \
+    && rm -rf photutils* \

--- a/rules/tractor.sh
+++ b/rules/tractor.sh
@@ -4,6 +4,7 @@ curl -SL http://github.com/dstndstn/tractor/archive/dr4.1.tar.gz \
     && cd tractor-dr4.1 \
     && CC="@CC@" CXX="@CXX@" CFLAGS="@CFLAGS@" CXXFLAGS="@CXXFLAGS@" make \
     SUITESPARSE_LIB_DIR="@AUX_PREFIX@/lib" BLAS_LIB="@BLAS@" \
+    PKG_CONFIG_PATH="@AUX_PREFIX@/share/pkgconfig" \
     && make install INSTALL_DIR=@AUX_PREFIX@ \
     && cd .. \
     && rm -rf tractor*


### PR DESCRIPTION
@tskisner 

Thanks for an beautiful desiconda Ted!

Two fixes
- Ceres was built fine, but Tractor's makefile uses "PKG_CONFIG_PATH" to search for "eigen3.pc", and installing Tractor's ceres modules fails when it doesn't find it. I pointed PKG_CONFIG_PATH to the right place and it now it works.
- The Imaging pipeline uses "fpack" and "funpack" which required adding "make fpack && make funpack" to the cfitsio build

One addition
- I added a "rules/photutils.sh" build. Maybe it is fine as is, but it needs Cython and at least when I ran the relevant lines it couldn't find cython packages in $AUX_PREFIX or $CONDA_PREFIX. I did a "pip install --no-deps cython --target $AUX_PREFIX/lib/python2.7/site-packages", but I'm sure you have a much better way?

One issue
- On Cori, fpack/funpack work fine, but not on Edison. I think the libraries are outdated as typing "fpack" or "funpack" results in:
fpack: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by fpack)
fpack: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /global/cscratch1/sd/kaylanb/software/desiconda/edison_kaylans/lib/libcfitsio.so.5)

Best,
Kaylan


