### PR TITLE
added pip packages: pytest, pytest-cov, coveralls 

### DIFF
--- a/rules/pip_pkgs.sh
+++ b/rules/pip_pkgs.sh
@@ -2,4 +2,7 @@ pip install --no-binary :all: \
     speclite \
     hpsspy \
     photutils \
-    https://github.com/esheldon/fitsio/archive/v0.9.12rc1.zip
+    https://github.com/esheldon/fitsio/archive/v0.9.12rc1.zip \
+    pytest \
+    pytest-cov \
+    coveralls 


### PR DESCRIPTION
@tskisner , 

I added some unit tests using pytest and its plugin for coveralls to the imaging code base. The docs for these recommend pip installing so I added them to **rules/pip_pkgs.sh**

I tested the three-line change by successfully building and installing conda  with "cori-gcc-py27".

Let me know!
-Kaylan