### PR TITLE
desiconda updates for the 18.7 software release

### DIFF
--- a/rules/astrometry_net.sh
+++ b/rules/astrometry_net.sh
@@ -1,6 +1,6 @@
-curl -SL https://github.com/dstndstn/astrometry.net/archive/0.73.tar.gz -o astrometry.net-0.73.tar.gz \
-    && tar xzf astrometry.net-0.73.tar.gz \
-    && cd astrometry.net-0.73 \
+curl -SL https://github.com/dstndstn/astrometry.net/archive/0.74.tar.gz -o astrometry.net-0.74.tar.gz \
+    && tar xzf astrometry.net-0.74.tar.gz \
+    && cd astrometry.net-0.74 \
     && CC="@CC@" CXX="@CXX@" CFLAGS="@CFLAGS@" CXXFLAGS="@CXXFLAGS@" \
     LDFLAGS="-L@AUX_PREFIX@/lib -lz" LDSHARED="@CC@ -shared" \
     WCSLIB_INC="-I@AUX_PREFIX@/include/wcslib" \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -23,6 +23,8 @@ conda install --copy --yes \
     scikit-image \
     ipython \
     jupyter \
+    ipywidgets=6.0.0 \
+    bokeh \
     && mplrc="@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages/matplotlib/mpl-data/matplotlibrc"; \
     cat ${mplrc} | sed -e "s#^backend.*#backend : TkAgg#" > ${mplrc}.tmp; \
     mv ${mplrc}.tmp ${mplrc} \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -5,7 +5,8 @@ conda install --copy --yes \
     cython \
     numpy \
     scipy \
-    matplotlib \
+    matplotlib=2.1.2 \
+    basemap \
     seaborn \
     pyyaml \
     astropy=2 \
@@ -22,7 +23,6 @@ conda install --copy --yes \
     scikit-image \
     ipython \
     jupyter \
-    && conda install -c conda-forge --copy --yes basemap \
     && mplrc="@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages/matplotlib/mpl-data/matplotlibrc"; \
     cat ${mplrc} | sed -e "s#^backend.*#backend : TkAgg#" > ${mplrc}.tmp; \
     mv ${mplrc}.tmp ${mplrc} \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -8,7 +8,7 @@ conda install --copy --yes \
     matplotlib \
     seaborn \
     pyyaml \
-    astropy=1.3.3 \
+    astropy=2 \
     hdf5 \
     h5py \
     psutil \

--- a/rules/pip_pkgs.sh
+++ b/rules/pip_pkgs.sh
@@ -3,4 +3,5 @@ pip install --no-binary :all: \
     hpsspy \
     photutils \
     coveralls \
+    line_profiler \
     https://github.com/esheldon/fitsio/archive/v0.9.12rc1.zip

--- a/rules/tractor.sh
+++ b/rules/tractor.sh
@@ -1,7 +1,7 @@
-curl -SL https://github.com/dstndstn/tractor/archive/dr6.2.tar.gz \
-    -o tractor-dr6.2.tar.gz \
-    && tar xzf tractor-dr6.2.tar.gz \
-    && cd tractor-dr6.2 && patch -p1 < ../rules/patch_tractor \
+curl -SL https://github.com/dstndstn/tractor/archive/dr7.0.tar.gz \
+    -o tractor-dr7.0.tar.gz \
+    && tar xzf tractor-dr7.0.tar.gz \
+    && cd tractor-dr7.0 && patch -p1 < ../rules/patch_tractor \
     && CERES_LIB_DIR="@AUX_PREFIX@/lib" \
     CC="@CC@" CFLAGS="@CFLAGS@" LDSHARED="@CC@ -shared" \
     CXX="@CXX@" CXXFLAGS="@CXXFLAGS@" BLAS_LIB="@BLAS@" \


### PR DESCRIPTION
This PR includes changes for the 18.7 software release:
  * astropy 2
  * pins matplotlib version due to incompatibility with basemap
  * adds ipywidgets and bokeh for spectral viewer
  * adds line_profiler (via pip install)
  * updates to astrometry.net/0.74 and tractor/dr7.0 (for imaging)

These are installed and tested as  desiconda 20180709-1.2.6-spec on cori and edison.  After this is merged I'll make the 1.2.6 tag.