### PR TITLE
workaround conda sudo badness

### DIFF
--- a/tools/install_imaging.in
+++ b/tools/install_imaging.in
@@ -33,6 +33,7 @@ export PKG_CONFIG_PATH=@AUX_PREFIX@/lib/pkgconfig:${PKG_CONFIG_PATH}
 export PKG_CONFIG_PATH=@AUX_PREFIX@/share/pkgconfig:${PKG_CONFIG_PATH}
 
 export ACCEPT_INTEL_PYTHON_EULA=yes
+unset SUDO_USER SUDO_GID SUDO_UID SUDO_COMMAND
 
 # Install conda root environment
 

--- a/tools/install_minimal.in
+++ b/tools/install_minimal.in
@@ -33,6 +33,7 @@ export PKG_CONFIG_PATH=@AUX_PREFIX@/lib/pkgconfig:${PKG_CONFIG_PATH}
 export PKG_CONFIG_PATH=@AUX_PREFIX@/share/pkgconfig:${PKG_CONFIG_PATH}
 
 export ACCEPT_INTEL_PYTHON_EULA=yes
+unset SUDO_USER SUDO_GID SUDO_UID SUDO_COMMAND
 
 # Install conda root environment
 

--- a/tools/install_spectro.in
+++ b/tools/install_spectro.in
@@ -33,6 +33,7 @@ export PKG_CONFIG_PATH=@AUX_PREFIX@/lib/pkgconfig:${PKG_CONFIG_PATH}
 export PKG_CONFIG_PATH=@AUX_PREFIX@/share/pkgconfig:${PKG_CONFIG_PATH}
 
 export ACCEPT_INTEL_PYTHON_EULA=yes
+unset SUDO_USER SUDO_GID SUDO_UID SUDO_COMMAND
 
 # Install conda root environment
 


### PR DESCRIPTION
This PR works around a bug/feature of conda to enable the desiconda build to work when using collabsu to become the desi pseudo-user at NERSC.  For some crazy reason conda tries to un-sudo itself back to the original user, and thus hits file permission problems.  The older deprecated method of using gsissh to become desi works, and with this PR using collabsu also works.

This is not needed for the 18.6 release, and will become moot with some future conda release (apparently they fixed this already in master but it hasn't made it into a tag).

Thanks to Wahid @ NERSC for identifying the problem and workaround.