### PR TITLE
Fix docker-gcc lapacke bug

### DIFF
--- a/conf/docker-gcc
+++ b/conf/docker-gcc
@@ -27,8 +27,8 @@ MPI_LDFLAGS = /usr/lib
 MPI_CXXLIB = mpichcxx
 MPI_LIB = mpich
 
-BLAS_INCLUDE =
-BLAS = -lopenblas -lm
-LAPACK = -llapack
+BLAS_INCLUDE = /usr/include
+BLAS = -lm -lblas
+LAPACK = -llapack -llapacke
 
 BOOSTCHAIN = gcc

--- a/rules/wcslib.sh
+++ b/rules/wcslib.sh
@@ -1,7 +1,7 @@
-curl -SL ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.16.tar.bz2 \
-    -o wcslib-5.16.tar.bz2 \
-    && tar xjf wcslib-5.16.tar.bz2 \
-    && cd wcslib-5.16 \
+curl -SL ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.20.tar.bz2 \
+    -o wcslib-5.20.tar.bz2 \
+    && tar xjf wcslib-5.20.tar.bz2 \
+    && cd wcslib-5.20 \
     && chmod -R u+w . \
     && patch -p1 < ../rules/patch_wcslib \
     && autoconf \

--- a/tools/Dockerfile_imaging.in
+++ b/tools/Dockerfile_imaging.in
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update \
     && apt-get install -y curl procps build-essential gfortran git subversion \
     python libcairo2-dev libpixman-1-dev libgsl-dev flex pkg-config cmake \
-    autoconf m4 libtool automake locales libopenblas-dev \
+    autoconf m4 libtool automake locales libopenblas-dev liblapacke-dev \
     && rm -fr /var/lib/apt/lists/*
 
 # Set up locales, to workaround a pip bug


### PR DESCRIPTION
Fixes #24.

Basically something needed to be specified for BLAS_INCLUDE so that the compiler could run. 

Also the -llapacke needed to be specified.

And liblapacke-dev needed to be installed via apt packages. 