### PR TITLE
updates for desiconda/20190804-1.3.0-spec

### DIFF
--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -6,7 +6,7 @@ conda install --copy --yes \
     cmake \
     numpy \
     scipy \
-    matplotlib \
+    matplotlib=2.1.2 \
     basemap \
     seaborn \
     pyyaml \
@@ -26,6 +26,7 @@ conda install --copy --yes \
     jupyter \
     ipywidgets \
     bokeh \
+    && conda install dask distributed -c conda-forge \
     && mplrc="@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages/matplotlib/mpl-data/matplotlibrc"; \
     cat ${mplrc} | sed -e "s#^backend.*#backend : TkAgg#" > ${mplrc}.tmp; \
     mv ${mplrc}.tmp ${mplrc} \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -16,7 +16,7 @@ conda install --copy --yes \
     psutil \
     ephem \
     psycopg2 \
-    pytest \
+    pytest=3.6.2 \
     pytest-cov \
     numba \
     sqlalchemy \

--- a/tools/install_spectro.in
+++ b/tools/install_spectro.in
@@ -42,6 +42,7 @@ unset SUDO_USER SUDO_GID SUDO_UID SUDO_COMMAND
 # Install conda root environment
 
 echo Installing conda root environment at $(date)
+
 @conda_root@
 
 if [ "x@INTEL_CONDA@" = "xyes" ]; then
@@ -51,6 +52,7 @@ fi
 # Install conda packages.
 
 echo Installing conda packages at $(date)
+
 @conda_pkgs@
 
 conda list --export | grep -v conda > "@CONDA_PREFIX@/pkg_list.txt"
@@ -58,6 +60,7 @@ conda list --export | grep -v conda > "@CONDA_PREFIX@/pkg_list.txt"
 # Install pip packages.
 
 echo Installing pip packages at $(date)
+
 @pip_pkgs@
 
 # Copy patches
@@ -91,46 +94,55 @@ fi
 # Install mpi4py.
 
 echo Installing mpi4py at $(date)
+
 @mpi4py@
 
 # Install CFITSIO.
 
 echo Installing cfitsio at $(date)
+
 @cfitsio@
 
 echo Installing fitsverify at $(date)
+
 @fitsverify@
 
 # Install OpenBLAS
 
 if [ "x@INTEL_COMP@" != "xyes" ]; then
 echo Installing OpenBLAS at $(date)
+
 @openblas@
 fi
 
 # Install FFTW.
 
 echo Installing FFTW at $(date)
+
 @fftw@
 
 # Install BOOST.
 
 echo Installing BOOST at $(date)
+
 @boost@
 
 # Install HARP.
 
 echo Installing HARP at $(date)
+
 @harp@
 
 # Install PyMPIT for environment testing
 
 echo Installing PyMPIT at $(date)
+
 @pympit@
 
 # GalSim and dependencies
 
 echo Installing GalSim and friends at $(date)
+
 @scons@
 
 @tmv@
@@ -147,6 +159,7 @@ fi
 # Compile python modules
 
 echo Pre-compiling python modules at $(date)
+
 python@PYVERSION@ -m compileall -f "@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages"
 python@PYVERSION@ -m compileall -f "@AUX_PREFIX@"
 
@@ -154,12 +167,14 @@ python@PYVERSION@ -m compileall -f "@AUX_PREFIX@"
 # install prefix
 
 echo Import python modules that might trigger downloads at $(date)
+
 python@PYVERSION@ -c "import astropy"
 python@PYVERSION@ -c "import matplotlib.font_manager as fm; f = fm.FontManager"
 
 # Set permissions
 
 echo Setting permissions at $(date)
+
 if [ "x@CHGRP@" != "x" ]; then
     chgrp -R @CHGRP@ "@AUX_PREFIX@"
     chgrp -R @CHGRP@ "@CONDA_PREFIX@"
@@ -173,6 +188,7 @@ fi
 # Install modulefile
 
 echo Installing the desiconda modulefile at $(date)
+
 if [ "x@MODULE_DIR@" != "x" ]; then
     mkdir -p "@MODULE_DIR@"
     cp "${fullscript}.module" "@MODULE_DIR@/@VERSION@"

--- a/tools/install_spectro.in
+++ b/tools/install_spectro.in
@@ -41,6 +41,7 @@ unset SUDO_USER SUDO_GID SUDO_UID SUDO_COMMAND
 
 # Install conda root environment
 
+echo Installing conda root environment at $(date)
 @conda_root@
 
 if [ "x@INTEL_CONDA@" = "xyes" ]; then
@@ -49,12 +50,14 @@ fi
 
 # Install conda packages.
 
+echo Installing conda packages at $(date)
 @conda_pkgs@
 
 conda list --export | grep -v conda > "@CONDA_PREFIX@/pkg_list.txt"
 
 # Install pip packages.
 
+echo Installing pip packages at $(date)
 @pip_pkgs@
 
 # Copy patches
@@ -68,6 +71,8 @@ fi
 
 # Autotools
 
+echo Installing autotools at $(date)
+
 @m4@
 
 @libtool@
@@ -79,43 +84,53 @@ fi
 # MPICH if needed
 
 if [ "x@BUILD_MPI@" = "xyes" ]; then
+echo Installing mpich at $(date)
 @mpich@
 fi
 
 # Install mpi4py.
 
+echo Installing mpi4py at $(date)
 @mpi4py@
 
 # Install CFITSIO.
 
+echo Installing cfitsio at $(date)
 @cfitsio@
 
+echo Installing fitsverify at $(date)
 @fitsverify@
 
 # Install OpenBLAS
 
 if [ "x@INTEL_COMP@" != "xyes" ]; then
+echo Installing OpenBLAS at $(date)
 @openblas@
 fi
 
 # Install FFTW.
 
+echo Installing FFTW at $(date)
 @fftw@
 
 # Install BOOST.
 
+echo Installing BOOST at $(date)
 @boost@
 
 # Install HARP.
 
+echo Installing HARP at $(date)
 @harp@
 
 # Install PyMPIT for environment testing
 
+echo Installing PyMPIT at $(date)
 @pympit@
 
 # GalSim and dependencies
 
+echo Installing GalSim and friends at $(date)
 @scons@
 
 @tmv@
@@ -131,17 +146,20 @@ fi
 
 # Compile python modules
 
+echo Pre-compiling python modules at $(date)
 python@PYVERSION@ -m compileall -f "@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages"
 python@PYVERSION@ -m compileall -f "@AUX_PREFIX@"
 
 # Import packages that may need to generate files in the
 # install prefix
 
+echo Import python modules that might trigger downloads at $(date)
 python@PYVERSION@ -c "import astropy"
 python@PYVERSION@ -c "import matplotlib.font_manager as fm; f = fm.FontManager"
 
 # Set permissions
 
+echo Setting permissions at $(date)
 if [ "x@CHGRP@" != "x" ]; then
     chgrp -R @CHGRP@ "@AUX_PREFIX@"
     chgrp -R @CHGRP@ "@CONDA_PREFIX@"
@@ -154,6 +172,7 @@ fi
 
 # Install modulefile
 
+echo Installing the desiconda modulefile at $(date)
 if [ "x@MODULE_DIR@" != "x" ]; then
     mkdir -p "@MODULE_DIR@"
     cp "${fullscript}.module" "@MODULE_DIR@/@VERSION@"

--- a/tools/install_spectro.in
+++ b/tools/install_spectro.in
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo Starting desiconda installation at $(date)
+
 # Script directory
 
 pushd $(dirname $0) > /dev/null
@@ -177,3 +179,7 @@ echo "export PYTHONPATH=@AUX_PREFIX@/lib/python@PYVERSION@/site-packages" >> ${s
 echo "export PKG_CONFIG_PATH=@AUX_PREFIX@/lib/pkgconfig:\${PKG_CONFIG_PATH}" >> ${setupfile}
 echo "export PKG_CONFIG_PATH=@AUX_PREFIX@/share/pkgconfig:\${PKG_CONFIG_PATH}" >> ${setupfile}
 echo "" >> ${setupfile}
+
+# All done
+
+echo Done at $(date)

--- a/tools/modulefile.in
+++ b/tools/modulefile.in
@@ -37,6 +37,7 @@ unsetenv PYTHONSTARTUP
 prepend-path PATH "@CONDA_PREFIX@/bin"
 setenv PYTHONPATH "@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages"
 setenv DESICONDA "@CONDA_PREFIX@"
+setenv DESICONDA_VERSION "@VERSION@"
 setenv DESICONDA_EXTRA "@AUX_PREFIX@"
 
 # This is the location of the extra compiled software

--- a/tools/modulefile.in
+++ b/tools/modulefile.in
@@ -40,6 +40,9 @@ setenv DESICONDA "@CONDA_PREFIX@"
 setenv DESICONDA_VERSION "@VERSION@"
 setenv DESICONDA_EXTRA "@AUX_PREFIX@"
 
+# for basemap; see https://github.com/matplotlib/basemap/issues/419
+setenv PROJ_LIB "@CONDA_PREFIX@/share/proj"
+
 # This is the location of the extra compiled software
 prepend-path PATH "@AUX_PREFIX@/bin"
 prepend-path CPATH "@AUX_PREFIX@/include"


### PR DESCRIPTION
This PR has the changes used for the desiconda/20190804-1.3.0-spec installation at NERSC, to be tagged as 1.3.0.

  * pin pytest version for compatibility with specsim+astropy tests
  * pin matplotlib version (I don't recall exactly why, but it was purposeful to work around some problem uncovered in testing)
  * added dask and distributed conda packages for R&D / exploratory work
  * adds progress messages with timestamps during installation
  * as part of the installed modulefile:
    * sets `$DESICONDA_VERSION` (for convenience; previously this was available by parsing directory paths in `$DESICONDA` and `$DESICONDA_EXTRA`, but not as an environment variable with just the version.
    * sets `$PROJ_LIB` (needed by basemap)