### PR TITLE
desiconda used for 20200801 and 20.7 software release

### DIFF
--- a/conf/cori-gcc
+++ b/conf/cori-gcc
@@ -30,7 +30,7 @@ CROSS =
 
 INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.6
+PYVERSION = 3.8
 
 # Use Cray MPICH
 

--- a/conf/cori-gcc
+++ b/conf/cori-gcc
@@ -30,7 +30,7 @@ CROSS =
 
 INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.8
+PYVERSION = 3.7
 
 # Use Cray MPICH
 

--- a/conf/cori-gcc
+++ b/conf/cori-gcc
@@ -30,7 +30,7 @@ CROSS =
 
 INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.7
+PYVERSION = 3.8
 
 # Use Cray MPICH
 

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -11,6 +11,7 @@ conda install --copy --yes \
     seaborn \
     pyyaml \
     astropy \
+    pytest-astropy \
     hdf5 \
     h5py \
     psutil \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -6,17 +6,17 @@ conda install --copy --yes \
     cmake \
     numpy \
     scipy \
-    matplotlib=2.1.2 \
+    matplotlib \
     basemap \
     seaborn \
     pyyaml \
-    astropy=2 \
+    astropy \
     hdf5 \
     h5py \
     psutil \
     ephem \
     psycopg2 \
-    pytest=3.6.2 \
+    pytest \
     pytest-cov \
     numba \
     sqlalchemy \
@@ -28,6 +28,7 @@ conda install --copy --yes \
     bokeh \
     wurlitzer \
     certipy \
+    sphinx \
     && conda install --copy --yes -c conda-forge dask distributed \
     && mplrc="@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages/matplotlib/mpl-data/matplotlibrc"; \
     cat ${mplrc} | sed -e "s#^backend.*#backend : TkAgg#" > ${mplrc}.tmp; \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -6,8 +6,8 @@ conda install --copy --yes \
     cmake \
     numpy \
     scipy \
+    mkl=2020.0 \
     matplotlib \
-    basemap \
     seaborn \
     pyyaml \
     astropy \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -29,7 +29,9 @@ conda install --copy --yes \
     wurlitzer \
     certipy \
     sphinx \
-    && conda install --copy --yes -c conda-forge dask distributed \
+    iminuit \
+    cudatoolkit \
+    && conda install --copy --yes -c conda-forge dask distributed papermill \
     && mplrc="@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages/matplotlib/mpl-data/matplotlibrc"; \
     cat ${mplrc} | sed -e "s#^backend.*#backend : TkAgg#" > ${mplrc}.tmp; \
     mv ${mplrc}.tmp ${mplrc} \

--- a/rules/conda_pkgs.sh
+++ b/rules/conda_pkgs.sh
@@ -31,8 +31,12 @@ conda install --copy --yes \
     sphinx \
     iminuit \
     cudatoolkit \
-    && conda install --copy --yes -c conda-forge dask distributed papermill \
-    && mplrc="@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages/matplotlib/mpl-data/matplotlibrc"; \
+&& conda install --copy --yes -c conda-forge \
+    fitsio \
+    dask \
+    distributed \
+    papermill \
+&& mplrc="@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages/matplotlib/mpl-data/matplotlibrc"; \
     cat ${mplrc} | sed -e "s#^backend.*#backend : TkAgg#" > ${mplrc}.tmp; \
     mv ${mplrc}.tmp ${mplrc} \
-    && rm -rf @CONDA_PREFIX@/pkgs/*
+&& rm -rf @CONDA_PREFIX@/pkgs/*

--- a/rules/pip_pkgs.sh
+++ b/rules/pip_pkgs.sh
@@ -5,4 +5,5 @@ pip install --no-binary :all: \
     healpy \
     coveralls \
     line_profiler \
-    fitsio
+    fitsio \
+    cupy-cuda102

--- a/rules/pip_pkgs.sh
+++ b/rules/pip_pkgs.sh
@@ -5,4 +5,4 @@ pip install --no-binary :all: \
     healpy \
     coveralls \
     line_profiler \
-    https://github.com/esheldon/fitsio/archive/v0.9.12rc1.zip
+    fitsio

--- a/rules/pip_pkgs.sh
+++ b/rules/pip_pkgs.sh
@@ -1,9 +1,9 @@
 pip install --no-binary :all: \
-    speclite \
+    https://github.com/desihub/speclite/archive/v0.9.tar.gz \
     hpsspy \
     photutils \
     healpy \
     coveralls \
-    line_profiler \
-    fitsio \
-    cupy-cuda102
+&& pip install \
+    cupy-cuda102 \
+    line_profiler

--- a/tools/install_spectro.in
+++ b/tools/install_spectro.in
@@ -2,6 +2,9 @@
 
 echo Starting desiconda installation at $(date)
 
+# print commands as they are run so we know where we are if something fails
+set -x
+
 # Script directory
 
 pushd $(dirname $0) > /dev/null
@@ -55,6 +58,11 @@ echo Installing conda packages at $(date)
 
 @conda_pkgs@
 
+if [ $? != 0 ]; then
+    echo "ERROR installing conda packages; exiting"
+    exit 1
+fi
+
 conda list --export | grep -v conda > "@CONDA_PREFIX@/pkg_list.txt"
 
 # Install pip packages.
@@ -62,6 +70,11 @@ conda list --export | grep -v conda > "@CONDA_PREFIX@/pkg_list.txt"
 echo Installing pip packages at $(date)
 
 @pip_pkgs@
+
+if [ $? != 0 ]; then
+    echo "ERROR installing pip packages; exiting"
+    exit 1
+fi
 
 # Copy patches
 

--- a/tools/modulefile.in
+++ b/tools/modulefile.in
@@ -51,10 +51,6 @@ prepend-path LIBRARY_PATH "@AUX_PREFIX@/lib"
 prepend-path PYTHONPATH "@AUX_PREFIX@/lib/python@PYVERSION@/site-packages"
 prepend-path PKG_CONFIG_PATH "@AUX_PREFIX@/lib/pkgconfig"
 
-# The NERSC "sqs" command is a python script with a hard-coded
-# interpreter that is incompatible.
-set-alias "sqs" "python /usr/common/software/bin/sqs"
-
 # Set environment variables possibly needed for compiling spectro pipeline
 
 # FIXME: Disabling these for now, since they override


### PR DESCRIPTION
This PR documents the changes used for the desiconda 20200801-1.4.0-spec installation used as the base for the DESI 20.7 software release.

The primary goals were to
* upgrade to python 3.8.x, fitsio 1.x, astropy 4.x, bokeh 2.x
* add iminuit (for future desitarget) and  pycuda (for perlmutter prep)
* add for convenience / experimentation: papermill, dask/distributed, sphinx

This environment is available at NERSC via
```
source /global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/setup_desiconda.sh
```
Or including all the desi packages
```
source /global/cfs/cdirs/desi/software/desi_environment.sh 20.7
```