### PR TITLE
Add xlrd to pip-installed packages.

### DIFF
--- a/rules/pip_pkgs.sh
+++ b/rules/pip_pkgs.sh
@@ -7,4 +7,5 @@ pip install --no-binary :all: \
 && pip install \
     cupy-cuda102 \
     line_profiler \
-    xlrd
+    xlrd \
+    configobj

--- a/rules/pip_pkgs.sh
+++ b/rules/pip_pkgs.sh
@@ -6,4 +6,5 @@ pip install --no-binary :all: \
     coveralls \
 && pip install \
     cupy-cuda102 \
-    line_profiler
+    line_profiler \
+    xlrd


### PR DESCRIPTION
The `desi_focalplane_sync` script needs to read petal verification files (xls format) from DocDB to build the positioner to fiber mapping.  Although this script is only used by experts and cron jobs, having this package as part of desiconda would allow us to use the default desi stack when running this script (rather than standing up a separate virtualenv just to run the script).