### PR TITLE
Add fitsverify

### DIFF
--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -6,6 +6,7 @@ conda install --copy --yes -c conda-forge \
     astropy \
     speclite \
     fitsio \
+    fitsverify \
     libblas=*=*mkl \
     dask \
     distributed \


### PR DESCRIPTION
Fixes #46 by adding the fitsverify package to the conda install command explicitly. Manual update with desiconda loaded using:
```
$DESICONDA/bin/activate
conda install --copy --yes -c conda-forge fitsverify
```
is successful and does not result in any package updates. 

@sbailey please review, post-facto install fitsverify to /global/common/software/desi/cori/desiconda/20200801-1.4.0-spec using the above commands, and merge if appropriate. 