### PR TITLE
Pin condatoolkit to v11.5

### DIFF
--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -43,7 +43,7 @@ conda install --copy --yes -c conda-forge \
     certipy \
     sphinx \
     iminuit \
-    cudatoolkit \
+    cudatoolkit=11.5 \
     cupy \
     healpy \
     photutils \


### PR DESCRIPTION
Use condatoolkit v11.5, consistent with the latest version available on Perlmutter.