### PR TITLE
Updated support for data transfer nodes (datatran)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+miniconda.sh

--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,17 @@ configured a different desiconda / desi_environment, then::
     unset PYTHONPATH
     export DCONDAVERSION=$(date '+%Y%m%d')-2.0.1.dev
     PREFIX=${prefix} ./install.sh |& tee install.log
+
+To load this version of desiconda::
+
     module use ${prefix}/${DCONDAVERSION}/modulefiles
     module load desiconda
 
 Then install a suite of desispec, desiutil, etc. modules::
 
     source scripts/bootstrap-desi.sh
+
+After that you can ``module load desiutil`` etc.
 
 Example
 -------

--- a/README.rst
+++ b/README.rst
@@ -8,35 +8,35 @@ Introduction
 This package contains scripts for installing conda and all compiled
 dependencies needed by the spectroscopic pipeline.
 
-Quick start installation 
+Quick start installation
 ------------------------
 
 To install desiconda and load module::
 
-    # set target 
-    prefix=/global/common/software/desi/users/$USER/desiconda
-    mkdir -p $prefix 
+    # set target
+    prefix=/global/common/software/desi/users/${USER}/desiconda
+    mkdir -p ${prefix}
 
-    local_copy=/global/cfs/cdirs/desi/users/$USER/desiconda
-    git clone https://github.com/desihub/desiconda $local_copy
-    cd $local_copy
+    local_copy=/global/cfs/cdirs/desi/users/${USER}/desiconda
+    git clone https://github.com/desihub/desiconda ${local_copy}
+    cd ${local_copy}
 
     unset PYTHONPATH
-    export DCONDAVERSION=$(date '+%Y%m%d')-2.0.1dev
-    PREFIX=$prefix ./install.sh |& tee install.log
-    module use $prefix/$DCONDAVERSION/modulefiles
+    export DCONDAVERSION=$(date '+%Y%m%d')-2.0.1.dev
+    PREFIX=${prefix} ./install.sh |& tee install.log
+    module use ${prefix}/${DCONDAVERSION}/modulefiles
     module load desiconda
 
 Then install a suite of desispec, desiutil, etc. modules::
 
     source scripts/bootstrap-desi.sh
-    
+
 Example
-----------------
+-------
 
 Imagine you wanted to install a set of dependencies for DESI software on a
-cluster (rather than manually getting all the dependencies in place).  
-You plan on installing desiconda in your home directory ($HOME/software/desi)
+cluster (rather than manually getting all the dependencies in place).
+You plan on installing desiconda in your home directory (``${HOME}/software/desi``)
 and you want to have the custom string "my-desiconda" associated with your
 installation.
 
@@ -63,26 +63,31 @@ If everything worked, then you can see your new desiconda install with::
 
 And you can load it with::
 
-    $> module load desiconda/$dcondaversion 
+    $> module load desiconda/$dcondaversion
 
 Configuration
-~~~~~~~~~~~~~~~~~~
+-------------
 
-If environment and pacakge files (conf/[envtag]-env.sh and conf/[pkgtag]-pkgs.sh) for
+If environment and package files (``conf/[envtag]-env.sh`` and ``conf/[pkgtag]-pkgs.sh``) for
 your use case already exists in the "conf" directory, then
-just use them.  Otherwise, create or edit files in the "conf" subdirectory that 
+just use them.  Otherwise, create or edit files in the "conf" subdirectory that
 are named after the environment and set of packages you wish to create and install.
-See existing files conf/default-env.sh and conf/default-pkgs.sh for spectroscopic
-pipeline dependencies on cori. 
+See existing files ``conf/default-env.sh`` and ``conf/default-pkgs.sh ``for spectroscopic
+pipeline dependencies on cori.
+
+For ``${NERSC_HOST} == "datatran"`` installs use::
+
+    PREFIX=${prefix} PKGS=datatran install.sh
+
+as in the example above.
 
 Contents of installation
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
-The installation directory (assuming the installation script was called with 
-$DCONDAVERSION and $PREFIX) will contain directories and files::
+The installation directory (assuming the installation script was called with
+``${DCONDAVERSION}`` and ``${PREFIX}``) will contain directories and files::
 
-    $PREFIX/desiconda/$DCONDAVERSION/conda
-    $PREFIX/desiconda/$DCONDAVERSION/aux
-    $PREFIX/desiconda/$DCONDAVERSION/modulefiles/desiconda/$DCONDAVERSION
-    $PREFIX/desiconda/$DCONDAVERSION/modulefiles/desiconda/.version_$DCONDAVERSION
-
+    ${PREFIX}/desiconda/${DCONDAVERSION}/conda
+    ${PREFIX}/desiconda/${DCONDAVERSION}/aux
+    ${PREFIX}/desiconda/${DCONDAVERSION}/modulefiles/desiconda/$DCONDAVERSION
+    ${PREFIX}/desiconda/${DCONDAVERSION}/modulefiles/desiconda/.version_$DCONDAVERSION

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,8 @@ dependencies needed by the spectroscopic pipeline.
 Quick start installation
 ------------------------
 
-To install desiconda and load module::
+To install desiconda, start with a terminal where you have *not*
+configured a different desiconda / desi_environment, then::
 
     # set target
     prefix=/global/common/software/desi/users/${USER}/desiconda

--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -4,7 +4,6 @@ echo condadir is $CONDADIR
 
 conda install --copy --yes -c conda-forge \
     astropy \
-    speclite \
     fitsio \
     fitsverify \
     libblas=*=*mkl \

--- a/conf/datatran-pkgs.sh
+++ b/conf/datatran-pkgs.sh
@@ -1,0 +1,40 @@
+# conda packages
+echo Current time $(date) Installing conda packages
+echo condadir is $CONDADIR
+
+conda install --copy --yes -c conda-forge \
+    astropy \
+    fitsio \
+    fitsverify \
+    matplotlib \
+    requests \
+    pyyaml \
+    hdf5 \
+    h5py \
+    healpy \
+    sphinx \
+    pytest \
+    pytest-cov \
+    pytest-astropy \
+    coveralls \
+    && rm -rf $CONDADIR/pkgs/*
+
+if [ $? != 0 ]; then
+    echo "ERROR installing conda packages; exiting"
+    exit 1
+fi
+
+conda list --export | grep -v conda > "$CONDADIR/pkg_list.txt"
+echo Current time $(date) Done installing conda packages
+
+# Install pip packages.
+echo Installing pip packages at $(date)
+
+pip install hpsspy sphinx-toolbox
+
+if [ $? != 0 ]; then
+    echo "ERROR installing pip packages; exiting"
+    exit 1
+fi
+
+echo Current time $(date) Done installing pip packages

--- a/conf/nersc-env.sh
+++ b/conf/nersc-env.sh
@@ -1,5 +1,5 @@
 # export MINICONDA=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-# miniforge solves fast and works well with conda-forge 
+# miniforge solves fast and works well with conda-forge
 export MINICONDA=https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh
 export CONDAVERSION=2.0
 export GRP=desi
@@ -21,9 +21,11 @@ elif [ "${NERSC_HOST}" == "perlmutter" ] ; then
   export MPICC="cc -target-accel=nvidia80 -shared"
 fi
 
-module unload darshan            # not necessary and suspected to generate overhead
-module unload altd               # not necessary and suspected to cause random job hangs
-module unload craype-hugepages2M # https://docs.nersc.gov/development/languages/python/faq-troubleshooting
+if [[ "${NERSC_HOST}" != "datatran" ]]; then
+    module unload darshan            # not necessary and suspected to generate overhead
+    module unload altd               # not necessary and suspected to cause random job hangs
+    module unload craype-hugepages2M # https://docs.nersc.gov/development/languages/python/faq-troubleshooting
+fi
 
 for PRGENV in $(echo gnu intel cray nvidia)
 do

--- a/install.sh
+++ b/install.sh
@@ -21,9 +21,6 @@ popd > /dev/null
 scriptname=$(basename $0)
 fullscript="${topdir}/${scriptname}"
 
-# Convenience environment variables
-SWAPPRGENV=$topdir/scripts/SwapPrgEnv.sh
-
 CONFDIR=$topdir/conf
 
 CONFIGUREENV=$CONFDIR/$CONF-env.sh
@@ -44,7 +41,7 @@ MODULEDIR=$DESICONDA/modulefiles/desiconda
 echo Installing conda root environment at $(date)
 
 mkdir -p $AUXDIR/bin
-mkdir -p $AUXDIR/lib 
+mkdir -p $AUXDIR/lib
 
 mkdir -p $CONDADIR/bin
 mkdir -p $CONDADIR/lib

--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -21,9 +21,9 @@ for pkg in $pkgs; do
     # install branches/master and filter bogus error messages
     echo desiInstalling $pkg
     branch=branches/main
-    if [ $pkg == "QuasarNP" ] ; then branch="0.1.3"; fi
+    if [ $pkg == "QuasarNP" ] ; then branch="0.1.5"; fi
     if [ $pkg == "desitree" ] ; then branch="0.6.0"; fi
-    if [ $pkg ==   "specex" ] ; then branch="0.8.3"; fi
+    if [ $pkg ==   "specex" ] ; then branch="0.8.4"; fi
     desiInstall -v -r $base $pkg $branch
 done
 

--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -10,19 +10,22 @@ fi
 # Install desiutil to get desiInstall script
 pip install git+https://github.com/desihub/desiutil.git
 
-pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP"
+if [[ "${NERSC_HOST}" == "datatran" ]]; then
+    pkgs="desiutil desitree desiBackup desidatamodel desitransfer desida"
+else
+    pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP"
+fi
 export DESI_SPX_MKL=true
 base=$(realpath $DESICONDA/..)
 for pkg in $pkgs; do
     # install branches/master and filter bogus error messages
     echo desiInstalling $pkg
-    branch=branches/master
+    branch=branches/main
     if [ $pkg == "QuasarNP" ] ; then branch="0.1.2"; fi
-    if [ $pkg == "desitree" ] ; then branch="0.5.0"; fi
+    if [ $pkg == "desitree" ] ; then branch="0.6.0"; fi
     if [ $pkg ==   "specex" ] ; then branch="0.8.3"; fi
     desiInstall -v -r $base $pkg $branch
 done
 
 # remove pip desiutil because we'll use the desiutil module now
 pip uninstall desiutil --yes
-

--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -21,7 +21,7 @@ for pkg in $pkgs; do
     # install branches/master and filter bogus error messages
     echo desiInstalling $pkg
     branch=branches/main
-    if [ $pkg == "QuasarNP" ] ; then branch="0.1.2"; fi
+    if [ $pkg == "QuasarNP" ] ; then branch="0.1.3"; fi
     if [ $pkg == "desitree" ] ; then branch="0.6.0"; fi
     if [ $pkg ==   "specex" ] ; then branch="0.8.3"; fi
     desiInstall -v -r $base $pkg $branch


### PR DESCRIPTION
This PR:

* Closes #55. Extraneous line removed.
* Closes #54. Rename "master" to "main" in bootstrap script.
* Closes #53. speclite is installed by bootstrap script, not conda/pip.
* Closes #15.

It would be useful for someone to test whether this breaks anything on cori or perlmutter.