### PR TITLE
KPNO install fix

### DIFF
--- a/conf/kpno-env.sh
+++ b/conf/kpno-env.sh
@@ -1,0 +1,12 @@
+# export MINICONDA=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+# miniforge solves fast and works well with conda-forge
+export MINICONDA=https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh
+export CONDAVERSION=2.0
+export GRP=datasystems
+export CONDAPRGENV=gnu
+
+export CC="gcc"
+export FC="gfortran"
+export CFLAGS="-O3 -fPIC -pthread"
+export FCFLAGS="-O3 -fPIC -pthread -fexceptions"
+export NTMAKE=8

--- a/conf/kpno-pkgs.sh
+++ b/conf/kpno-pkgs.sh
@@ -1,0 +1,2 @@
+source $CONFDIR/conda-pkgs.sh
+

--- a/conf/pip-pkgs.sh
+++ b/conf/pip-pkgs.sh
@@ -1,17 +1,15 @@
 # Install pip packages.
-if [ "$HOSTNAME" != "desi-7" ]; then
-    echo Installing pip packages at $(date)
+echo Installing pip packages at $(date)
 
-    pip install --no-binary :all: hpsspy
-    pip install threadpoolctl
+pip install --no-binary :all: hpsspy
+pip install threadpoolctl
 
-    # see https://docs.nersc.gov/development/languages/python/parallel-python/
-    pip install --force --no-cache-dir --no-binary=mpi4py mpi4py
+# see https://docs.nersc.gov/development/languages/python/parallel-python/
+pip install --force --no-cache-dir --no-binary=mpi4py mpi4py
 
-    if [ $? != 0 ]; then
-        echo "ERROR installing pip packages; exiting"
-        exit 1
-    fi
-
-    echo Current time $(date) Done installing conda packages
+if [ $? != 0 ]; then
+    echo "ERROR installing pip packages; exiting"
+    exit 1
 fi
+
+echo Current time $(date) Done installing conda packages

--- a/conf/pip-pkgs.sh
+++ b/conf/pip-pkgs.sh
@@ -1,15 +1,17 @@
 # Install pip packages.
-echo Installing pip packages at $(date)
+if [ "$HOSTNAME" != "desi-7" ]; then
+    echo Installing pip packages at $(date)
 
-pip install --no-binary :all: hpsspy
-pip install threadpoolctl
+    pip install --no-binary :all: hpsspy
+    pip install threadpoolctl
 
-# see https://docs.nersc.gov/development/languages/python/parallel-python/
-pip install --force --no-cache-dir --no-binary=mpi4py mpi4py
+    # see https://docs.nersc.gov/development/languages/python/parallel-python/
+    pip install --force --no-cache-dir --no-binary=mpi4py mpi4py
 
-if [ $? != 0 ]; then
-    echo "ERROR installing pip packages; exiting"
-    exit 1
+    if [ $? != 0 ]; then
+        echo "ERROR installing pip packages; exiting"
+        exit 1
+    fi
+
+    echo Current time $(date) Done installing conda packages
 fi
-
-echo Current time $(date) Done installing conda packages

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,8 @@ echo Using Python version $PYVERSION
 
 # Prior to installing packages, switch to the fast libmamba package solver.
 echo Installing the libmamba package solver
-conda install -n base conda-libmamba-solver
+conda config --set solver classic
+conda install -n base conda-libmamba-solver -y
 conda config --set solver libmamba
 
 # Install packages

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,11 @@ source $CONDADIR/bin/activate
 export PYVERSION=$(python -c "import sys; print(str(sys.version_info[0])+'.'+str(sys.version_info[1]))")
 echo Using Python version $PYVERSION
 
+# Prior to installing packages, switch to the fast libmamba package solver.
+echo Installing the libmamba package solver
+conda install -n base conda-libmamba-solver
+conda config --set solver libmamba
+
 # Install packages
 source $INSTALLPKGS
 

--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -13,7 +13,11 @@ pip install git+https://github.com/desihub/desiutil.git
 if [[ "${NERSC_HOST}" == "datatran" ]]; then
     pkgs="desiutil desitree desiBackup desidatamodel desitransfer desida"
 else
-    pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP"
+    if [[ "${HOSTNAME}" == "desi-7" ]]; then
+        pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite nightwatch"
+    else
+        pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP"
+    fi
 fi
 export DESI_SPX_MKL=true
 base=$(realpath $DESICONDA/..)

--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -13,7 +13,7 @@ pip install git+https://github.com/desihub/desiutil.git
 if [[ "${NERSC_HOST}" == "datatran" ]]; then
     pkgs="desiutil desitree desiBackup desidatamodel desitransfer desida"
 else
-    if [[ "${HOSTNAME}" == "desi-7" ]]; then
+    if [ "${HOSTNAME}" == "desi-7" ] || [ "${HOSTNAME}" == "desi-8" ]; then
         pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite nightwatch"
     else
         pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP desisim-testdata desisurveyops"


### PR DESCRIPTION
A few changes to enable installation of desiconda packages on desi-7, intended to address the problems raised in #59:
- Disable pip installation of `hpsspy` and `mpi4py`.
- Disable installation of `specex` (requires BLAS libraries not installed) and QuasarNP.
- Enable installation of `nightwatch` as a module.