### PR TITLE
add mkdocs to default packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 desiconda Change Log
 ====================
 
+2.1.1 (unreleased)
+------------------
+
+* Add mkdocs to default packages (PR `#62`_).
+
+.. _`#62`: https://github.com/desihub/desiconda/pull/62
+
 2.1.0 (2022-09-28)
 ------------------
 

--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -52,6 +52,7 @@ conda install --copy --yes -c conda-forge \
     cupy \
     line_profiler \
     galsim \
+    mkdocs \
     altair \
     vega_datasets \
 && mplrc="$CONDADIR/lib/python$PYVERSION/site-packages/matplotlib/mpl-data/matplotlibrc"; \


### PR DESCRIPTION
Add mkdocs to default packages.  This is used for building desidatadocs deployed to https://data.desi.lbl.gov/doc .  Also see #61 