### PR TITLE
Update packages and bootstrap for Jura run

### DIFF
--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -2,12 +2,24 @@
 echo Current time $(date) Installing conda packages
 echo condadir is $CONDADIR
 
+# Notes:
+# - cupy-core instead of cupy so that it won't install any cuda libraries,
+#   which we will get from NERSC cudatoolkit module instead
+# - mkl=2020.0 because that is the last version that guarantees bitwise
+#   identical output for bitwise idential input
+# - bokeh<3 because prospect and nightwatch don't yet support bokeh 3
+# - numpy<2.0 because we haven't tested with numpy 2.x yet.
+# - ucx constraint is to avoid bringing in cuda libraries due to mal-formed
+#   dependencies "dask -> pyarrow -> libarrow -> ucx"
+#   https://github.com/conda-forge/ucx-split-feedstock/issues/172
+
 conda install --copy --yes -c conda-forge \
     astropy \
     fitsio \
     fitsverify \
     libblas=*=*mkl \
     dask \
+    "ucx=1.14.1=*_0" \
     distributed \
     papermill \
     nose \
@@ -42,7 +54,7 @@ conda install --copy --yes -c conda-forge \
     certipy \
     sphinx \
     iminuit \
-    cupy \
+    cupy-core \
     healpy \
     photutils \
     specutils \
@@ -54,6 +66,7 @@ conda install --copy --yes -c conda-forge \
     mkdocs \
     altair \
     vega_datasets \
+    conda-tree \
 && mplrc="$CONDADIR/lib/python$PYVERSION/site-packages/matplotlib/mpl-data/matplotlibrc"; \
     cat ${mplrc} | sed -e "s#^backend.*#backend : TkAgg#" > ${mplrc}.tmp; \
     mv ${mplrc}.tmp ${mplrc} \

--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -15,7 +15,7 @@ conda install --copy --yes -c conda-forge \
     future \
     cython \
     cmake \
-    numpy \
+    "numpy<2.0" \
     scipy \
     intel-openmp \
     mkl=2020.0 \
@@ -37,12 +37,11 @@ conda install --copy --yes -c conda-forge \
     ipython \
     jupyter \
     ipywidgets \
-    bokeh \
+    "bokeh<3" \
     wurlitzer \
     certipy \
     sphinx \
     iminuit \
-    cudatoolkit=11.5 \
     cupy \
     healpy \
     photutils \
@@ -50,7 +49,6 @@ conda install --copy --yes -c conda-forge \
     xlrd \
     coveralls \
     configobj \
-    cupy \
     line_profiler \
     galsim \
     mkdocs \

--- a/conf/pip-pkgs.sh
+++ b/conf/pip-pkgs.sh
@@ -1,7 +1,10 @@
 # Install pip packages.
 echo Installing pip packages at $(date)
 
-pip install --no-binary :all: hpsspy
+#- SB 2024-03-22: previous hpsspy install method fails, but basic install works
+# pip install --no-binary :all: hpsspy
+pip install hpsspy
+
 pip install threadpoolctl
 
 # see https://docs.nersc.gov/development/languages/python/parallel-python/
@@ -12,4 +15,4 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
-echo Current time $(date) Done installing conda packages
+echo Current time $(date) Done installing pip packages

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,9 @@ done
 echo Starting desiconda installation at $(date)
 SECONDS=0
 
+# Print every command run as part of log
+set -o xtrace
+
 # Defaults
 if [ -z $CONF ] ; then CONF=nersc;   fi
 if [ -z $PKGS ] ; then PKGS=default; fi
@@ -26,8 +29,6 @@ CONFDIR=$topdir/conf
 CONFIGUREENV=$CONFDIR/$CONF-env.sh
 INSTALLPKGS=$CONFDIR/$PKGS-pkgs.sh
 
-export PATH=$CONDADIR/bin:$PATH
-
 # Initialize environment
 source $CONFIGUREENV
 
@@ -36,6 +37,8 @@ DESICONDA=$PREFIX/$DCONDAVERSION
 CONDADIR=$DESICONDA/conda
 AUXDIR=$DESICONDA/aux
 MODULEDIR=$DESICONDA/modulefiles/desiconda
+
+export PATH=$CONDADIR/bin:$PATH
 
 # Install conda root environment
 echo Installing conda root environment at $(date)
@@ -54,11 +57,16 @@ source $CONDADIR/bin/activate
 export PYVERSION=$(python -c "import sys; print(str(sys.version_info[0])+'.'+str(sys.version_info[1]))")
 echo Using Python version $PYVERSION
 
-# Prior to installing packages, switch to the fast libmamba package solver.
-echo Installing the libmamba package solver
-conda config --set solver classic
-conda install -n base conda-libmamba-solver -y
-conda config --set solver libmamba
+## Update to latest conda
+# conda update -n base -c conda-forge conda
+
+## Prior to installing packages, switch to the fast libmamba package solver.
+## Disabled because miniconda how includes the mamba solver by default
+#
+# echo Installing the libmamba package solver
+# conda config --set solver classic
+# conda install -n base conda-libmamba-solver -y
+# conda config --set solver libmamba
 
 # Install packages
 source $INSTALLPKGS
@@ -72,7 +80,7 @@ python$PYVERSION -m compileall -f "$CONDADIR/lib/python$PYVERSION/site-packages"
 echo Setting permissions at $(date)
 
 chgrp -R $GRP $CONDADIR
-chmod -R u=rwX,g=rX,o-rwx $CONDADIR
+chmod -R u=rwX,g=rX,o=rX $CONDADIR
 
 # Install modulefile
 echo Installing the desiconda modulefile at $(date)
@@ -91,7 +99,7 @@ cp desiconda.module $MODULEDIR/$DCONDAVERSION
 cp desiconda.modversion $MODULEDIR/.version_$DCONDAVERSION
 
 chgrp -R $GRP $MODULEDIR
-chmod -R u=rwX,g=rX,o-rwx $MODULEDIR
+chmod -R u=rwX,g=rX,o=rx $MODULEDIR
 
 # All done
 echo Done at $(date)

--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -32,10 +32,30 @@ for pkg in $pkgs; do
     # some packages we special-case to tagged versions
     if [ $pkg == "QuasarNP" ] ; then branch="0.1.5"; fi
     if [ $pkg == "desitree" ] ; then branch="0.6.0"; fi
-    if [ $pkg ==   "specex" ] ; then branch="0.8.6"; fi
+    ### if [ $pkg ==   "specex" ] ; then branch="0.8.6"; fi
 
     desiInstall -v -r $base $pkg $branch
+
+    # special case to compile specex and fiberassign main
+    if [ $pkg == "specex" ] ; then
+        module load specex/main
+        pushd $SPECEX
+        python setup.py build_ext --inplace
+        popd
+    fi
+
+    if [ $pkg == "fiberassign" ] ; then
+        module load fiberassign/main
+        pushd $FIBERASSIGN
+        python setup.py build_ext --inplace
+        popd
+    fi
 done
+
+# install dust module from an earlier version of desiconda
+pushd $PREFIX
+cp -r 20230111-2.1.0/modulefiles/dust $DCONDAVERSION/modulefiles/
+popd
 
 # remove pip desiutil because we'll use the desiutil module now
 pip uninstall desiutil --yes

--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Bootstrap a set of DESI modules for their master branch
+# Bootstrap installation of the main branch of a set of DESI modules
 
 if [ -z "$DESICONDA" ] || [ -z "$DESICONDA_VERSION" ]; then
     echo "Load a desiconda module first to get \$DESICONDA and $DESICONDA_VERSION"
@@ -8,26 +8,32 @@ if [ -z "$DESICONDA" ] || [ -z "$DESICONDA_VERSION" ]; then
 fi
 
 # Install desiutil to get desiInstall script
+# (will remove this later after installing the desiutil module)
 pip install git+https://github.com/desihub/desiutil.git
 
 if [[ "${NERSC_HOST}" == "datatran" ]]; then
+    # NERSC Data Transfer Nodes have minimal environment
     pkgs="desiutil desitree desiBackup desidatamodel desitransfer desida"
+elif [ "${HOSTNAME}" == "desi-7" ] || [ "${HOSTNAME}" == "desi-8" ]; then
+    # KPNO have most packages, but not specex QuasarNP, ...
+    pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite nightwatch"
 else
-    if [ "${HOSTNAME}" == "desi-7" ] || [ "${HOSTNAME}" == "desi-8" ]; then
-        pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite nightwatch"
-    else
-        pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP desisim-testdata desisurveyops"
-    fi
+    # Default is everything
+    pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP desisim-testdata desisurveyops specprod-db fastspecfit"
 fi
+
 export DESI_SPX_MKL=true
 base=$(realpath $DESICONDA/..)
 for pkg in $pkgs; do
-    # install branches/master and filter bogus error messages
+    # install branches/main
     echo desiInstalling $pkg
     branch=branches/main
+
+    # some packages we special-case to tagged versions
     if [ $pkg == "QuasarNP" ] ; then branch="0.1.5"; fi
     if [ $pkg == "desitree" ] ; then branch="0.6.0"; fi
-    if [ $pkg ==   "specex" ] ; then branch="0.8.4"; fi
+    if [ $pkg ==   "specex" ] ; then branch="0.8.6"; fi
+
     desiInstall -v -r $base $pkg $branch
 done
 


### PR DESCRIPTION
This PR updates the packages and bootstrap procedure used for the 20240425-2.2.0 environment used for the Jura run.

Of particular note is the use of cupy-core instead of cupy so that it will *not* install any cuda modules, enabling us to use the NERSC-provided cudatoolkit for better compatibility.