### PR TITLE
add desiBackup, etc. to default installs

### DIFF
--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -19,7 +19,7 @@ elif [ "${HOSTNAME}" == "desi-7" ] || [ "${HOSTNAME}" == "desi-8" ]; then
     pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite nightwatch"
 else
     # Default is everything
-    pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP desisim-testdata desisurveyops specprod-db fastspecfit gfa_reduce"
+    pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite specex QuasarNP desisim-testdata desisurveyops specprod-db fastspecfit gfa_reduce desiBackup desida desidatamodel"
 fi
 
 export DESI_SPX_MKL=true


### PR DESCRIPTION
This PR adds `desiBackup`, `desida` and `desidatamodel` to the packages installed via `bootstrap-desi.sh`.