### PR TITLE
Update bootstrap file for KPNO package access.

### DIFF
--- a/scripts/bootstrap-desi.sh
+++ b/scripts/bootstrap-desi.sh
@@ -7,14 +7,31 @@ if [ -z "$DESICONDA" ] || [ -z "$DESICONDA_VERSION" ]; then
     return
 fi
 
+iskpno=false
+if [[ "$HOSTNAME" == "desi-7" ]] || [[ "$HOSTNAME" == "desi-8" ]]; then
+    if [ "$USER" == "datasystems" ]; then
+        iskpno=true
+    else
+        echo "At KPNO, must run as datasystems."
+        return
+    fi
+fi
+
 # Install desiutil to get desiInstall script
 # (will remove this later after installing the desiutil module)
-pip install git+https://github.com/desihub/desiutil.git
+# Note that special instructions are needed at KPNO (desi-8).
+if [ $iskpno == true ]; then
+    ssh git@desi-general git -C desiutil fetch
+    git clone git@desi-general:desiutil
+    pip install -e desiutil
+else
+     pip install git+https://github.com/desihub/desiutil.git
+fi
 
 if [[ "${NERSC_HOST}" == "datatran" ]]; then
     # NERSC Data Transfer Nodes have minimal environment
     pkgs="desiutil desitree desiBackup desidatamodel desitransfer desida"
-elif [ "${HOSTNAME}" == "desi-7" ] || [ "${HOSTNAME}" == "desi-8" ]; then
+elif [ $iskpno == true ]; then
     # KPNO have most packages, but not specex QuasarNP, ...
     pkgs="desiutil desitree desispec specter gpu_specter desimodel desitarget specsim desisim fiberassign desisurvey surveysim redrock redrock-templates prospect desimeter simqso speclite nightwatch"
 else
@@ -34,7 +51,13 @@ for pkg in $pkgs; do
     if [ $pkg == "desitree" ] ; then branch="0.6.0"; fi
     ### if [ $pkg ==   "specex" ] ; then branch="0.8.6"; fi
 
-    desiInstall -v -r $base $pkg $branch
+    # Special instructions at KPNO
+    if [ $iskpno == true ]; then
+        echo desiInstall -v -p $pkg:git@desi-general:$pkg -r $base $pkg $branch
+        desiInstall -v -p $pkg:git@desi-general:$pkg -r $base $pkg $branch
+    else
+        desiInstall -v -r $base $pkg $branch
+    fi
 
     # special case to compile specex and fiberassign main
     if [ $pkg == "specex" ] ; then
@@ -53,9 +76,11 @@ for pkg in $pkgs; do
 done
 
 # install dust module from an earlier version of desiconda
-pushd $PREFIX
-cp -r 20230111-2.1.0/modulefiles/dust $DCONDAVERSION/modulefiles/
-popd
+if [ $iskpno == false ]; then
+    pushd $PREFIX
+    cp -r 20230111-2.1.0/modulefiles/dust $DCONDAVERSION/modulefiles/
+    popd
+fi
 
 # remove pip desiutil because we'll use the desiutil module now
 pip uninstall desiutil --yes


### PR DESCRIPTION
This bootstrap works with GitHub access restrictions at KPNO to download DESI packages. The [desiutil kpno-projects-update branch](https://github.com/desihub/desiutil/tree/kpno-projects-update) is required for the script to work on the DESI cluster.

Appropriate guards in the bootstrap script should leave its behavior unchanged for users at NERSC and elsewhere.